### PR TITLE
no signedIn:true on user registration

### DIFF
--- a/dist/reducers/current-user/index.js
+++ b/dist/reducers/current-user/index.js
@@ -22,6 +22,7 @@ var currentUser = function (state, action) {
         case types_1.VERIFY_TOKEN_REQUEST_SUCCEEDED:
             return __assign({}, state, { attributes: __assign({}, action.payload.userAttributes), isLoading: false, isSignedIn: true, hasVerificationBeenAttempted: true });
         case types_1.REGISTRATION_REQUEST_SUCCEEDED:
+          return __assign({}, state, { attributes: __assign({}, action.payload.userAttributes), isLoading: false });
         case types_1.SIGNIN_REQUEST_SUCCEEDED:
             return __assign({}, state, { attributes: __assign({}, action.payload.userAttributes), isLoading: false, isSignedIn: true });
         case types_1.VERIFY_TOKEN_REQUEST_FAILED:

--- a/src/reducers/current-user/index.ts
+++ b/src/reducers/current-user/index.ts
@@ -41,6 +41,11 @@ const currentUser = (state: User = initialUser, action: ReduxAction): User => {
         hasVerificationBeenAttempted: true,
       }
     case REGISTRATION_REQUEST_SUCCEEDED:
+      return {
+        ...state,
+        attributes: { ...action.payload.userAttributes },
+        isLoading: false
+      }
     case SIGNIN_REQUEST_SUCCEEDED:
       return {
         ...state,


### PR DESCRIPTION
After registration the user should not be logged in automatically, the backend might need the user to do more actions before the user can log in, for example it might require: email verification, more info, confirmed payment or more. 

The way I see it is the user being logged in after registration is a side effect, which we don't need, and we can easily avoid. (unless we rename this function: "registerAndSignInUser" which appears unnecessary)

Imho a better approach if you really want straight login after signup, would be to call register and then sign in. Such as: 

```
dispatch(registerUser(data))
    .then(response => dispatch(signInUser(data)))
```

You'll then be able to control precisely when to register, have the registration properly stored in your redux store history, and generally more atomic.